### PR TITLE
Use egg attribute of the links

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 
 from setuptools import setup, find_packages
 
+
 setup(
     name='bankbarcode',
     version='0.1.1',
@@ -13,7 +14,7 @@ setup(
     # We need python-barcode v0.8, to have Code128 (EAN128), not released yet
     # https://bitbucket.org/whitie/python-barcode/issues/16/pypi-08-release-request
     dependency_links=[
-        "https://bitbucket.org/whitie/python-barcode/get/6c22b96a2ca2.zip"
+        "https://bitbucket.org/whitie/python-barcode/get/6c22b96.zip#egg=pybarcode-0.8b1"
     ],
     install_requires=[
         'pybarcode>=0.8b1'


### PR DESCRIPTION
To correct install it you must do:

``` sh
$ python setup.py install
```

or

``` sh
$ pip install --process-dependency-links bankbarcode
```
